### PR TITLE
CI: Support latest GitHub runners, use latest working EDK2 release tag

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -55,11 +55,11 @@ jobs:
     - name: Set up Linux environment
       run: |
         sudo apt-get update
-        sudo apt-get -y --no-install-recommends install python3-distutils nasm uuid-dev ${{ matrix.TARGET_PKGS }}
+        sudo apt-get -y --no-install-recommends install python3-setuptools nasm uuid-dev ${{ matrix.TARGET_PKGS }}
 
     - name: Set up EDK2
       run: |
-        git clone --recursive https://github.com/tianocore/edk2.git
+        git clone --recursive https://github.com/tianocore/edk2.git -b edk2-stable202408.01
         make -C edk2/BaseTools
 
     - name: Build UEFI bootloader

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        arch: [x64, ia32, aa64, arm]
+        arch: [x64, ia32, aa64]
 
     steps:
     - name: Checkout repository and submodules


### PR DESCRIPTION
I was planning to create pull request to add support for `loongarch64` but noticed that CI broken this PR fixes those:

Reasons to changes:
- Ubuntu version is updated in GitHub runners so there is small change needed to package name.
- Latest Windows SDK does not support 32-bit ARM anymore (look: https://github.com/zufuliu/notepad4/issues/839)
- EDK2 have been heavily modified so locking to last working release tag for now.